### PR TITLE
chore: upgrade to paper-api 26.1.2 with Java 25 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           fetch-depth: 0  # Full history for better caching
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'  # Eclipse Foundation OpenJDK
           cache: 'gradle'
 

--- a/buildSrc/src/main/kotlin/paper-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/paper-plugin.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
         vendor.set(JvmVendorSpec.ADOPTIUM)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ group=com.example
 version=1.0.0
 
 # Minecraft version (for reference)
-minecraftVersion=1.21.4
+minecraftVersion=26.1.2
 
 # JVM settings
 org.gradle.jvmargs=-Xmx2G -Dfile.encoding=UTF-8

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.3.21"
-paper-api = "1.21.11-R0.1-SNAPSHOT"
+paper-api = "26.1.2.build.60-stable"
 shadow = "9.4.1"
 litecommands = "3.10.9"
 junit = "6.0.3"


### PR DESCRIPTION
Supersedes #49 (Dependabot's paper-api bump) which failed CI because the new Paper API requires Java 25.

## Changes
- Bump `paper-api` from `1.21.11-R0.1-SNAPSHOT` to `26.1.2.build.60-stable`
- Upgrade Java toolchain from **21 → 25** (required by paper-api 26.x)
- Update `minecraftVersion` to `26.1.2` for `plugin.yml` api-version (Paper's new CalVer scheme)
- Update `ci.yml` and `release.yml` to use JDK 25

## Root cause
Paper 26.x moved to a new versioning scheme (CalVer) and now requires JVM 25+. The Dependabot PR only bumped the version in `libs.versions.toml` but didn't update the Java toolchain configuration.

Closes #49